### PR TITLE
Persist ExtendedMobEffectData to NBT

### DIFF
--- a/Common/src/main/java/net/tslat/effectslib/api/ExtendedMobEffect.java
+++ b/Common/src/main/java/net/tslat/effectslib/api/ExtendedMobEffect.java
@@ -1,5 +1,6 @@
 package net.tslat.effectslib.api;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.damagesource.DamageSource;
@@ -228,6 +229,20 @@ public class ExtendedMobEffect extends MobEffect {
 	public boolean doClientSideEffectTick(MobEffectInstance effectInstance, LivingEntity entity) {
 		return false;
 	}
+
+	/**
+	 * Called when MobEffectInstance is loaded from NBT
+	 * @param nbt The compoundTag that the effect instance is loaded from
+	 * @param effectInstance The effect instance getting loaded
+	 */
+	public void read(CompoundTag nbt, MobEffectInstance effectInstance){};
+
+	/**
+	 * Called when MobEffectInstance is saved to NBT
+	 * @param nbt The compoundTag that the effect instance is saved to
+	 * @param effectInstance The effect instance getting saved
+	 */
+	public void write(CompoundTag nbt, MobEffectInstance effectInstance){};
 
 	// START DISABLED METHOD HANDLES
 

--- a/Common/src/main/java/net/tslat/effectslib/mixin/common/MobEffectInstanceMixin.java
+++ b/Common/src/main/java/net/tslat/effectslib/mixin/common/MobEffectInstanceMixin.java
@@ -1,5 +1,6 @@
 package net.tslat.effectslib.mixin.common;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
@@ -11,6 +12,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
@@ -64,6 +66,24 @@ public abstract class MobEffectInstanceMixin implements ExtendedMobEffectHolder 
 	private void checkEffectTick(LivingEntity entity, Runnable runnable, CallbackInfoReturnable<Boolean> callback) {
 		if (this.duration > 0 && this.getEffect() instanceof ExtendedMobEffect extendedEffect && extendedEffect.shouldTickEffect((MobEffectInstance)(Object)this, entity, this.duration, this.amplifier))
 			applyEffect(entity);
+	}
+
+	@Inject(
+			method = "writeDetailsTo",
+			at = @At(value = "TAIL")
+	)
+	private void write(CompoundTag pNbt, CallbackInfo ci) {
+		if (this.getEffect() instanceof ExtendedMobEffect extendedEffect)
+			extendedEffect.write(pNbt,(MobEffectInstance)(Object)this);
+	}
+
+	@Inject(
+			method = "loadSpecifiedEffect",
+			at = @At(value = "TAIL")
+	)
+	private static void load(MobEffect pEffect, CompoundTag pNbt, CallbackInfoReturnable<MobEffectInstance> cir) {
+		if (pEffect instanceof ExtendedMobEffect extendedEffect)
+			extendedEffect.read(pNbt,cir.getReturnValue());
 	}
 
 	@Override


### PR DESCRIPTION
Adds Save and Load methods to ExtendedMobEffect 
Mixin Injected at the tail of MobEffectInstance#loadSpecifiedEffect and MobEffectInstance#writeDetailsTo