### PR TITLE
Add constructor overload to ExtendedMobEffect

### DIFF
--- a/Common/src/main/java/net/tslat/effectslib/api/ExtendedMobEffect.java
+++ b/Common/src/main/java/net/tslat/effectslib/api/ExtendedMobEffect.java
@@ -34,8 +34,8 @@ public class ExtendedMobEffect extends MobEffect {
 	public ExtendedMobEffect(MobEffectCategory category, int color) {
 		super(category, color);
 	}
-	public ExtendedMobEffect(MobEffectCategory category, int color) {
-		super(category, color);
+	public ExtendedMobEffect(MobEffectCategory category, int color, ParticleOptions particle) {
+		super(category, color, particle)
 	}
 
 	/**

--- a/Common/src/main/java/net/tslat/effectslib/api/ExtendedMobEffect.java
+++ b/Common/src/main/java/net/tslat/effectslib/api/ExtendedMobEffect.java
@@ -34,6 +34,9 @@ public class ExtendedMobEffect extends MobEffect {
 	public ExtendedMobEffect(MobEffectCategory category, int color) {
 		super(category, color);
 	}
+	public ExtendedMobEffect(MobEffectCategory category, int color) {
+		super(category, color);
+	}
 
 	/**
 	 * Get the display name of the effect instance. Used for rendering the effects in inventories. <br>


### PR DESCRIPTION
Add constructor overload to `ExtendedMobEffect` with ParticleOptions parameter

Fixes #6 

Only making a PR for the version with the issue, but I have the changes completed in every branch